### PR TITLE
replacing BOTID by CHATID

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ apply Notification "Host by Telegram" to Host {
     users = [ "telegram_unixe" ]
     vars.notification_logtosyslog = true
     vars.telegram_bot = "<YOUR_TELEGRAM_BOT_NAME>"
-    vars.telegram_botid = "<YOUR_TELEGRAM_BOT_ID>"
+    vars.telegram_chatid = "<YOUR_TELEGRAM_CHAT_ID>"
     vars.telegram_bottoken = "<YOUR_TELEGRAM_BOT_TOKEN>"
 }
 ```

--- a/host-by-telegram.sh
+++ b/host-by-telegram.sh
@@ -26,7 +26,7 @@ The following are mandatory:
   -n HOSTDISPLAYNAME (\$host.display_name$)
   -o HOSTOUTPUT (\$host.output$)
   -p TELEGRAM_BOT (\$telegram_bot$)
-  -q TELEGRAM_BOTID (\$telegram_botid$)
+  -q TELEGRAM_CHATID (\$telegram_chatid$)
   -r TELEGRAM_BOTTOKEN (\$telegram_bottoken$)
   -s HOSTSTATE (\$host.state$)
   -t NOTIFICATIONTYPE (\$notification.type$)
@@ -56,7 +56,7 @@ do
     n) HOSTDISPLAYNAME=$OPTARG ;;
     o) HOSTOUTPUT=$OPTARG ;;
     p) TELEGRAM_BOT=$OPTARG ;;
-    q) TELEGRAM_BOTID=$OPTARG ;;
+    q) TELEGRAM_CHATID=$OPTARG ;;
     r) TELEGRAM_BOTTOKEN=$OPTARG ;;
     s) HOSTSTATE=$OPTARG ;;
     t) NOTIFICATIONTYPE=$OPTARG ;;

--- a/service-by-telegram.sh
+++ b/service-by-telegram.sh
@@ -27,7 +27,7 @@ The following are mandatory:
   -n HOSTDISPLAYNAME (\$host.display_name$)
   -o SERVICEOUTPUT (\$service.output$)
   -p TELEGRAM_BOT (\$telegram_bot$)
-  -q TELEGRAM_BOTID (\$telegram_botid$)
+  -q TELEGRAM_CHATID (\$telegram_chatid$)
   -r TELEGRAM_BOTTOKEN (\$telegram_bottoken$)
   -s SERVICESTATE (\$service.state$)
   -t NOTIFICATIONTYPE (\$notification.type$)
@@ -58,7 +58,7 @@ do
     n) HOSTDISPLAYNAME=$OPTARG ;;
     o) SERVICEOUTPUT=$OPTARG ;;
     p) TELEGRAM_BOT=$OPTARG ;; 
-    q) TELEGRAM_BOTID=$OPTARG ;; 
+    q) TELEGRAM_CHATID=$OPTARG ;;
     r) TELEGRAM_BOTTOKEN=$OPTARG ;;
     s) SERVICESTATE=$OPTARG ;;
     t) NOTIFICATIONTYPE=$OPTARG ;;


### PR DESCRIPTION
TELEGRAM_BOTID becomes TELEGRAM_CHATID

it is misleading to name it bot id - imho as the id we need here
is actually the chat id, either from a user or group.
that id is not related to the bot itself.