### PR TITLE
fix curl debug options

### DIFF
--- a/alert-by-telegram.sh
+++ b/alert-by-telegram.sh
@@ -171,15 +171,15 @@ fi
 
 # Debug output or not?
 if [[ -z ${DEBUG-} ]]; then
-	CURLARGS="--silent --output /dev/null"
+	CURLARGS=(--silent --output /dev/null)
 else
-	CURLARGS=-v
+	CURLARGS=(-v)
 	set -x
 	echo -e "DEBUG MODE!"
 fi
 
 # And finally, send the message
-/usr/bin/curl "${CURLARGS}" \
+/usr/bin/curl "${CURLARGS[@]}" \
 	--data-urlencode "chat_id=${TELEGRAM_CHATID}" \
 	--data-urlencode "text=${NOTIFICATION_MESSAGE}" \
 	--data-urlencode "parse_mode=HTML" \


### PR DESCRIPTION
Fixes argument interpretation of curl command.

When options `--silent` and `--output /dev/null` are put into the same string, following error appears:

```
curl: option --silent --output /dev/null: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
```

Creating a list where list elements are parsed to curl as arguments works as workaround.